### PR TITLE
enhance: accept promela files

### DIFF
--- a/app/helpers/file_helper.rb
+++ b/app/helpers/file_helper.rb
@@ -8,7 +8,7 @@ module FileHelper
   extend MimeCheckHelpers
 
   def known_extension?(extn)
-    allow_extensions = %w(pdf ps csv xls xlsx pas cpp c cs csv h hpp java py js html coffee scss yaml yml xml json ts r rb rmd rnw rhtml rpres tex vb sql txt md jack hack asm hdl tst out cmp vm sh bat dat ipynb css png bmp tiff tif jpeg jpg gif zip gz tar wav ogg mp3 mp4 webm aac pcm aiff flac wma alac)
+    allow_extensions = %w(pdf ps csv xls xlsx pas cpp c cs csv h hpp java py js html coffee scss yaml yml xml json ts r rb rmd rnw rhtml rpres tex vb sql txt md jack hack asm hdl tst out cmp vm sh bat dat ipynb css png bmp tiff tif jpeg jpg gif zip gz tar wav ogg mp3 mp4 webm aac pcm aiff flac wma alac pml)
 
     # Allow empty or nil extensions for blobs otherwise check that it matches the allowed list
     extn.nil? || extn.empty? || allow_extensions.include?(extn)

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1019,10 +1019,12 @@ class Task < ApplicationRecord
     elsif ['xml'].include?(extn) then 'xml'
     elsif ['sql'].include?(extn) then 'sql'
     elsif ['vb'].include?(extn) then 'vbnet'
-    elsif ['txt', 'md', 'rmd', 'rpres', 'hdl', 'asm', 'jack', 'hack', 'tst', 'cmp', 'vm', 'sh', 'bat', 'dat', 'csv'].include?(extn) then 'text'
+    elsif ['txt', 'md', 'rmd', 'rpres', 'hdl', 'asm', 'jack', 'hack', 'tst', 'cmp', 'vm', 'sh', 'bat', 'dat', 'csv', 'pml'].include?(extn) then 'text'
     elsif ['tex', 'rnw'].include?(extn) then 'tex'
     elsif ['py'].include?(extn) then 'python'
     elsif ['r'].include?(extn) then 'r'
+    # requres unreleased pygments v2.18 https://pygments.org/docs/lexers/#pygments.lexers.c_like.PromelaLexer
+    # elsif ['pml'].include?(extn) then 'promela'
     else extn
     end
   end


### PR DESCRIPTION
Render the file as plaintext until pygments v2.18 is released. Very trivial change, unit tests all pass locally.
Frontend change: https://github.com/thoth-tech/doubtfire-web/pull/160

Rendered PDF:
![image](https://github.com/thoth-tech/doubtfire-api/assets/90136978/3aa250c4-4f8e-4b45-a466-40510664bc2e)
