### PR TITLE
feat: added target grade change history feature

### DIFF
--- a/app/api/entities/project_entity.rb
+++ b/app/api/entities/project_entity.rb
@@ -28,5 +28,7 @@ module Entities
 
     expose :grade, if: :for_staff
     expose :grade_rationale, if: :for_staff
+
+    expose :target_grade_histories, using: Entities::TargetGradeHistoryEntity, if: ->(project, options) { options[:in_project] }
   end
 end

--- a/app/api/entities/target_grade_history_entity.rb
+++ b/app/api/entities/target_grade_history_entity.rb
@@ -1,0 +1,8 @@
+module Entities
+  class TargetGradeHistoryEntity < Grape::Entity
+    expose :previous_grade
+    expose :new_grade
+    expose :changed_at
+    expose :changed_by, using: Entities::Minimal::MinimalUserEntity
+  end
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -31,6 +31,8 @@ class Project < ApplicationRecord
 
   has_many :learning_outcome_task_links, through: :tasks
 
+  has_many :target_grade_histories, dependent: :destroy
+
   # Callbacks - methods called are private
   before_destroy :can_destroy?
 

--- a/app/models/target_grade_history.rb
+++ b/app/models/target_grade_history.rb
@@ -1,0 +1,7 @@
+class TargetGradeHistory < ApplicationRecord
+  belongs_to :project
+  belongs_to :user
+  belongs_to :changed_by, class_name: 'User', foreign_key: 'changed_by_id'
+
+  validates :project_id, :user_id, :previous_grade, :new_grade, :changed_at, presence: true
+end

--- a/db/migrate/20241113065336_create_target_grade_history.rb
+++ b/db/migrate/20241113065336_create_target_grade_history.rb
@@ -1,0 +1,14 @@
+class CreateTargetGradeHistory < ActiveRecord::Migration[7.1]
+  def change
+    create_table :target_grade_histories do |t|
+      t.integer :project_id, null: false #reference to the unit project
+      t.integer :user_id, null: false #This is where we refer to the student by the ID
+      t.string :previous_grade #Previous grade of the user before we update it
+      t.string :new_grade #Updated grade
+      t.integer :changed_by_id #Referene to the user who changed the grade
+      t.datetime :changed_at, null: false #The date time when the grade was changed
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_28_223908) do
+ActiveRecord::Schema[7.1].define(version: 2024_11_13_065336) do
   create_table "activity_types", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "abbreviation", null: false
@@ -190,6 +190,17 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_28_223908) do
   create_table "roles", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.text "description"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "target_grade_histories", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+    t.integer "project_id", null: false
+    t.integer "user_id", null: false
+    t.string "previous_grade"
+    t.string "new_grade"
+    t.integer "changed_by_id"
+    t.datetime "changed_at", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end


### PR DESCRIPTION
# Description

This PR introduces a new Target Grade Change History feature on the front end and the back end. The feature includes:
	•	A new table in the Progress Dashboard to display the history of changes made to a student’s target grade.
	•	Integration with the back-end API to fetch and render the target grade history dynamically.
	•	Relevant CoffeeScript and HTML updates to ensure seamless functionality and responsiveness.


## Type of change


- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

The changes were tested as follows:

1.	Visual Validation:
	•	Verified that the Target Grade Change History table renders correctly on the Progress Dashboard.
	•	Ensured responsive layout across devices.
2.	API Integration Testing:
	•	Confirmed data is fetched correctly from the back end and rendered in the front end.
	•	Tested error handling for scenarios like no data or failed API calls.

## Testing Checklist:

- [x] Tested in latest Chrome
- [x] Tested in latest Safari


# Checklist:

	My code follows the style guidelines of this project.
	•	I have performed a self-review of my code.
	•	I have commented my code, particularly in hard-to-understand areas.

Front end Pull Request -- https://github.com/thoth-tech/doubtfire-web/pull/262

<img width="977" alt="Screenshot 2024-11-14 at 7 35 26 pm" src="https://github.com/user-attachments/assets/c69d6f46-1c2b-4db7-9ac8-69012816b011">



