### PR TITLE
Feature/Create 'tutor_times' table and 'TutorTime' Model

### DIFF
--- a/app/models/tutor_time.rb
+++ b/app/models/tutor_time.rb
@@ -1,0 +1,12 @@
+class TutorTime < ApplicationRecord
+  belongs_to :user
+  belongs_to :task
+
+  validates :user_id, presence: true
+  validates :task_id, presence: true
+  validates :time_spent, presence: true, numericality: { greater_than_or_equal_to: 0 }
+
+  def time_spent_in_hours
+    time_spent.to_f / 60
+  end
+end

--- a/app/models/tutor_time.rb
+++ b/app/models/tutor_time.rb
@@ -4,9 +4,9 @@ class TutorTime < ApplicationRecord
 
   validates :user_id, presence: true
   validates :task_id, presence: true
-  validates :time_spent, presence: true, numericality: { greater_than_or_equal_to: 0 }
+  validates :time_spent, presence: true, numericality: { greater_than_or_equal_to: 0.0 }
 
   def time_spent_in_hours
-    time_spent.to_f / 60
+    (time_spent.to_f / 60.0).round(2)
   end
 end

--- a/db/migrate/20250324073540_create_tutor_times.rb
+++ b/db/migrate/20250324073540_create_tutor_times.rb
@@ -1,9 +1,9 @@
 class CreateTutorTimes < ActiveRecord::Migration[7.1]
   def change
     create_table :tutor_times do |t|
-      t.references :user, null: false, foreign_key: true  # Links to users table
-      t.references :task, null: false, foreign_key: true  # Links to tasks table
-      t.integer :time_spent, null: false, default: 0       # Time spent in minutes
+      t.references :user, null: false, foreign_key: true
+      t.references :task, null: false, foreign_key: true
+      t.integer :time_spent, null: false, default: 0
       t.timestamps
     end
   end

--- a/db/migrate/20250324073540_create_tutor_times.rb
+++ b/db/migrate/20250324073540_create_tutor_times.rb
@@ -1,8 +1,8 @@
 class CreateTutorTimes < ActiveRecord::Migration[7.1]
   def change
     create_table :tutor_times do |t|
-      t.references :user, null: false, foreign_key: true
-      t.references :task, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: { on_delete: :cascade }
+      t.references :task, null: false, foreign_key: { on_delete: :cascade }
       t.decimal :time_spent, precision: 10, scale: 2, null: false, default: 0.0
       t.timestamps
     end

--- a/db/migrate/20250324073540_create_tutor_times.rb
+++ b/db/migrate/20250324073540_create_tutor_times.rb
@@ -1,0 +1,10 @@
+class CreateTutorTimes < ActiveRecord::Migration[7.1]
+  def change
+    create_table :tutor_times do |t|
+      t.references :user, null: false, foreign_key: true  # Links to users table
+      t.references :task, null: false, foreign_key: true  # Links to tasks table
+      t.integer :time_spent, null: false, default: 0       # Time spent in minutes
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250324073540_create_tutor_times.rb
+++ b/db/migrate/20250324073540_create_tutor_times.rb
@@ -3,7 +3,7 @@ class CreateTutorTimes < ActiveRecord::Migration[7.1]
     create_table :tutor_times do |t|
       t.references :user, null: false, foreign_key: true
       t.references :task, null: false, foreign_key: true
-      t.integer :time_spent, null: false, default: 0
+      t.decimal :time_spent, precision: 10, scale: 2, null: false, default: 0.0
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_28_223908) do
+ActiveRecord::Schema[7.1].define(version: 2025_03_24_073540) do
   create_table "activity_types", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "abbreviation", null: false
@@ -394,6 +394,16 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_28_223908) do
     t.index ["tii_task_similarity_id"], name: "index_tii_submissions_on_tii_task_similarity_id"
   end
 
+  create_table "tutor_times", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "task_id", null: false
+    t.integer "time_spent", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["task_id"], name: "index_tutor_times_on_task_id"
+    t.index ["user_id"], name: "index_tutor_times_on_user_id"
+  end
+
   create_table "tutorial_enrolments", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -531,4 +541,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_28_223908) do
     t.index ["user_id"], name: "index_webcals_on_user_id", unique: true
   end
 
+  add_foreign_key "tutor_times", "tasks"
+  add_foreign_key "tutor_times", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -541,6 +541,6 @@ ActiveRecord::Schema[7.1].define(version: 2025_03_24_073540) do
     t.index ["user_id"], name: "index_webcals_on_user_id", unique: true
   end
 
-  add_foreign_key "tutor_times", "tasks"
-  add_foreign_key "tutor_times", "users"
+  add_foreign_key "tutor_times", "tasks", on_delete: :cascade
+  add_foreign_key "tutor_times", "users", on_delete: :cascade
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -397,7 +397,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_03_24_073540) do
   create_table "tutor_times", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "task_id", null: false
-    t.integer "time_spent", default: 0, null: false
+    t.decimal "time_spent", precision: 10, scale: 2, default: "0.0", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["task_id"], name: "index_tutor_times_on_task_id"


### PR DESCRIPTION
# Description
- Create 'tutor_times' table and 'TutorTime' model for Tutor Times Feature

## Type of change
- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
1. In your terminal, change directory to `doubtfire-api` - if you are in `doubtfire-deploy`, simply run the following:
```bash
cd doubtfire-api
```

2. Run the following to apply pending migrations and update your database schema:
```bash
rails db:migrate
```

3. Run the following to access the Ruby shell:
```bash
rails console
```

4. Finally, confirm that the tutor_times table has been added by ensuring all columns matches the migration. You can run this in the Ruby shell to return all the columns of the table:
```ruby
TutorTime.column_names
```
![image](https://github.com/user-attachments/assets/002b2059-4223-40d9-bd3e-0391cfe439d2)

**Migration File:**
![image](https://github.com/user-attachments/assets/e77640f2-e81b-489b-a34d-4e87a7a313e3)


## Checklist

### If involving code

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation - **There is existing ticket in Backlog to update documentation for Backend - Tutor Times**
- [x] My changes generate no new warnings

## Folders and Files Added/Modified
- Added:
  - [x] app/models/tutor_time.rb
  - [x] db/migrate/20250324073540_create_tutor_times.rb
- Modified:
  - [x] db/schema.rb
