### PR TITLE
Feature/Modify 'users' Table to add Total Tutor Time

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -144,6 +144,7 @@ class User < ApplicationRecord
   validates :username,    presence: true, uniqueness: { case_sensitive: false }
   validates :email,       presence: true, uniqueness: { case_sensitive: false }, format: { with: /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i }
   validates :student_id,  uniqueness: true, allow_nil: true
+  validates :total_tutor_time, presence: true, numericality: { greater_than_or_equal_to: 0.0 }
   validate :can_change_to_role?, if: :will_save_change_to_role_id?
 
   # Queries

--- a/db/migrate/20250326085802_add_total_tutor_time_to_users.rb
+++ b/db/migrate/20250326085802_add_total_tutor_time_to_users.rb
@@ -1,0 +1,5 @@
+class AddTotalTutorTimeToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :total_tutor_time, :decimal, precision: 10, scale: 2, null: false, default: 0.0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_28_223908) do
+ActiveRecord::Schema[7.1].define(version: 2025_03_26_085802) do
   create_table "activity_types", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "abbreviation", null: false
@@ -509,6 +509,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_28_223908) do
     t.string "tii_eula_version"
     t.datetime "tii_eula_date"
     t.boolean "tii_eula_version_confirmed", default: false, null: false
+    t.decimal "total_tutor_time", precision: 10, scale: 2, default: "0.0", null: false
     t.index ["login_id"], name: "index_users_on_login_id", unique: true
     t.index ["role_id"], name: "index_users_on_role_id"
   end


### PR DESCRIPTION
# Description
- Modify 'users' table to include total_tutor_time

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
1. In your terminal, change directory to `doubtfire-api` - if you are in `doubtfire-deploy`, simply run the following:
```bash
cd doubtfire-api
```

2. Run the following to apply pending migrations and update your database schema:
```bash
rails db:migrate
```

3. Run the following to access the Ruby shell:
```bash
rails console
```

4. Finally, confirm that the `total_tutor_time` has been added to `users` table has been added. You can run this in the Ruby shell to return all the columns of the table:
```ruby
User.column_names
```
![image](https://github.com/user-attachments/assets/57d78067-0a3b-4171-bfce-7e64cb4e1acf)


## Checklist

### If involving code

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation - **There is existing ticket in Backlog to update documentation for Backend - Tutor Times**
- [x] My changes generate no new warnings

## Folders and Files Added/Modified
- Added:
  
  - [x] db/migrate/20250326085802_add_total_tutor_time_to_users
- Modified:
  - [x] db/schema.rb
  - [x] app/models/user.rb
