### PR TITLE
fix(task): resolve feedback notification issue

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,6 +168,7 @@ GEM
     faraday-net_http (3.1.0)
       net-http
     ffi (1.17.0-aarch64-linux-gnu)
+    ffi (1.17.0-x86_64-linux-gnu)
     fugit (1.11.0)
       et-orbi (~> 1, >= 1.2.11)
       raabro (~> 1.4)
@@ -264,6 +265,8 @@ GEM
     netrc (0.11.0)
     nio4r (2.7.3)
     nokogiri (1.16.5-aarch64-linux)
+      racc (~> 1.4)
+    nokogiri (1.16.5-x86_64-linux)
       racc (~> 1.4)
     observer (0.1.2)
     orm_adapter (0.5.0)
@@ -490,6 +493,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   better_errors

--- a/app/api/users_api.rb
+++ b/app/api/users_api.rb
@@ -67,8 +67,8 @@ class UsersApi < Grape::API
     change_self = (params[:id] == current_user.id)
 
     params[:receive_portfolio_notifications] = true if params.key?(:receive_portfolio_notifications) && params[:receive_portfolio_notifications].nil?
-    params[:receive_portfolio_notifications] = true if params.key?(:receive_feedback_notifications) && params[:receive_feedback_notifications].nil?
-    params[:receive_portfolio_notifications] = true if params.key?(:receive_task_notifications) && params[:receive_task_notifications].nil?
+    params[:receive_feedback_notifications] = true if params.key?(:receive_feedback_notifications) && params[:receive_feedback_notifications].nil?
+    params[:receive_task_notifications] = true if params.key?(:receive_task_notifications) && params[:receive_task_notifications].nil?
 
     # can only modify if current_user.id is same as :id provided
     # (i.e., user wants to update their own data) or if update_user token

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -132,6 +132,7 @@ class Task < ApplicationRecord
   delegate :update_task_stats, to: :project
 
   after_update :update_task_stats, if: :saved_change_to_task_status_id? # TODO: consider moving to async task
+  after_update :send_feedback_notification, if: :saved_change_to_task_status_id?
 
   validates :task_definition_id, uniqueness: { scope: :project,
                                                message: 'must be unique within the project' }
@@ -1360,6 +1361,20 @@ class Task < ApplicationRecord
     end
     # we got to the end so no match
     nil
+  end
+
+  def send_feedback_notification
+    return unless task_status.in?([TaskStatus.redo, TaskStatus.fail, TaskStatus.fix_and_resubmit, TaskStatus.feedback_exceeded, TaskStatus.discuss, TaskStatus.demonstrate, TaskStatus.complete])
+    return unless project.student.receive_feedback_notifications
+    return unless unit.send_notifications
+
+    begin
+      logger.info "Checking feedback email for project #{project.id}"
+      logger.info "Emailing feedback notification to #{project.student.name}"
+      PortfolioEvidenceMailer.task_feedback_ready(project, [self]).deliver
+    rescue => e
+      logger.error "Failed to send feedback notification email. Error: #{e.message}"
+    end
   end
 
   private

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1511,7 +1511,7 @@ class Task < ApplicationRecord
 def send_feedback_notification
     return unless task_status.in?([TaskStatus.redo, TaskStatus.fail, TaskStatus.fix_and_resubmit, TaskStatus.feedback_exceeded, TaskStatus.discuss, TaskStatus.demonstrate, TaskStatus.complete])
     return unless project.student.receive_feedback_notifications
-    return unless unit.send_notifications
+    return unless unit&.send_notifications
 
     begin
       logger.info "Checking feedback email for project #{project.id}"

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -53,14 +53,21 @@ Doubtfire::Application.configure do
   # Store uploaded files on the local file system (see config/storage.yml for options).
   # config.active_storage.service = :local
 
-  # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
+ # Don't care if the mailer can't send.
+ config.action_mailer.raise_delivery_errors = true
 
-  config.action_mailer.perform_caching = false
+ config.action_mailer.perform_caching = false
 
-  # Tell Action Mailer not to deliver emails to the real world.
-  # Write them to file instead (under doubtfire-api/tmp/mails)
-  config.action_mailer.delivery_method = :file
+ # Tell Action Mailer not to deliver emails to the real world.
+ # Write them to file instead (under doubtfire-api/tmp/mails)
+ config.action_mailer.delivery_method = :file
+ config.action_mailer.file_settings = { 
+   :location => File.join(Rails.root, 'tmp', 'mails')
+ }
+ 
+ # Add more verbose logging for ActionMailer
+ config.action_mailer.logger = Logger.new(STDOUT)
+ config.action_mailer.logger.level = Logger::DEBUG
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -63,13 +63,7 @@ Doubtfire::Application.configure do
  # Tell Action Mailer not to deliver emails to the real world.
  # Write them to file instead (under doubtfire-api/tmp/mails)
  config.action_mailer.delivery_method = :file
- config.action_mailer.file_settings = { 
-   :location => File.join(Rails.root, 'tmp', 'mails')
- }
- 
- # Add more verbose logging for ActionMailer
- config.action_mailer.logger = Logger.new(STDOUT)
- config.action_mailer.logger.level = Logger::DEBUG
+
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log


### PR DESCRIPTION
Fixed an issue where feedback notifications were not sent when task status updated. Now, emails are correctly triggered based on status changes.

Fixes # (issue)
Fixes the Notification Mailer feature which notify students if the task status is changed into either of these (redo, fail, fix_and_resubmit, feedback_exceeded, discuss, demonstrate, complete)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test A
- Verified the Send Notifications is set as True for a particular unit by running an SQL Query
- Verified the Student has turned on their notification from the /edit-profile route
- Logged in as a tutor , selected the unit , selected the student assignment and marked it as fail
- Once the task status is marked as failed the notification will be sent to the student.
- The email can be viewed here in /tmp/mails with all the necessary details in it

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if appropriate
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have created or extended unit tests to address my new additions
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

If you have any questions, please contact @macite or @jakerenzella.
