### PR TITLE
Feature/import download tutorials csv backend

### DIFF
--- a/app/api/tutorials_api.rb
+++ b/app/api/tutorials_api.rb
@@ -3,6 +3,7 @@ require 'grape'
 class TutorialsApi < Grape::API
   helpers AuthenticationHelpers
   helpers AuthorisationHelpers
+  helpers MimeCheckHelpers
 
   before do
     authenticated?
@@ -107,22 +108,19 @@ class TutorialsApi < Grape::API
   params do
     requires :file, type: File, desc: 'CSV upload file.'
   end
-  post '/csv/tutorials' do
-    unless authorise? current_user, Tutorial, :upload_csv
+  post '/csv/tutorials/upload' do
+    unless authorise? current_user, User, :upload_csv
       error!({ error: "Not authorised to upload CSV of students of tutorials" }, 403)
     end
     if params[:file].blank?
       error!({ error: 'No file uploaded' }, 403)
     end
     path = params[:file][:tempfile].path
-    # check mime is correct before uploading
-    ensure_csv!(path)
-    # Actually import...
-    Tutorial.import_from_csv(current_user, File.new(path))
+    Tutorial.import_from_csv(File.new(path))
   end
 
   desc 'Download CSV with tutorials'
-  get '/csv/tutorials' do
+  get '/csv/tutorials/download' do
     unless authorise? current_user, User, :download_tutorial_csv
       error!({ error: 'Not authorised to download CSV of all tutorials' }, 403)
     end

--- a/app/api/tutorials_api.rb
+++ b/app/api/tutorials_api.rb
@@ -110,11 +110,17 @@ class TutorialsApi < Grape::API
   end
   post '/csv/tutorials/upload' do
     unless authorise? current_user, User, :upload_csv
-      error!({ error: "Not authorised to upload CSV of students of tutorials" }, 403)
+      error!({ error: 'Not authorised to upload CSV of students of tutorials' }, 403)
     end
+
     if params[:file].blank?
       error!({ error: 'No file uploaded' }, 403)
     end
+
+    if params[:file][:tempfile].size > 5.megabytes
+      error!({ error: 'CSV file size exceeds the 5MB limit' }, 413)
+    end
+
     path = params[:file][:tempfile].path
     Tutorial.import_from_csv(File.new(path))
   end

--- a/app/api/tutorials_api.rb
+++ b/app/api/tutorials_api.rb
@@ -102,4 +102,35 @@ class TutorialsApi < Grape::API
     tutorial.destroy!
     present true, with: Grape::Presenters::Presenter
   end
+
+  desc 'Upload CSV with tutorials'
+  params do
+    requires :file, type: File, desc: 'CSV upload file.'
+  end
+  post '/csv/tutorials' do
+    unless authorise? current_user, Tutorial, :upload_csv
+      error!({ error: "Not authorised to upload CSV of students of tutorials" }, 403)
+    end
+    if params[:file].blank?
+      error!({ error: 'No file uploaded' }, 403)
+    end
+    path = params[:file][:tempfile].path
+    # check mime is correct before uploading
+    ensure_csv!(path)
+    # Actually import...
+    Tutorial.import_from_csv(current_user, File.new(path))
+  end
+
+  desc 'Download CSV with tutorials'
+  get '/csv/tutorials' do
+    unless authorise? current_user, User, :download_tutorial_csv
+      error!({ error: 'Not authorised to download CSV of all tutorials' }, 403)
+    end
+
+    content_type 'application/octet-stream'
+    header['Content-Disposition'] = 'attachment; filename=tutorials.csv'
+    header['Access-Control-Expose-Headers'] = 'Content-Disposition'
+    env['api.format'] = :binary
+    Tutorial.export_to_csv
+  end
 end

--- a/app/models/tutorial.rb
+++ b/app/models/tutorial.rb
@@ -1,4 +1,7 @@
+require 'csv_helper'
+require 'csv'
 class Tutorial < ApplicationRecord
+  include CsvHelper
   # Model associations
   belongs_to :unit, optional: false # Foreign key
   belongs_to :unit_role, optional: true # Foreign key
@@ -71,6 +74,107 @@ class Tutorial < ApplicationRecord
 
   def num_students
     projects.where('enrolled = true').count
+  end
+
+  def self.missing_headers(row, headers)
+    headers - row.to_hash.keys
+  end
+
+  def self.csv_columns
+    %w[code abbreviation unit_id tutor_id tutorial_stream]
+  end
+
+  def self.import_from_csv(file)
+    success = []
+    errors = []
+    ignored = []
+    data = FileHelper.read_file_to_str(file).gsub('\\n', "\n")
+    CSV.parse(data,
+              headers: true,
+              header_converters: [->(i) { i.nil? ? '' : i }, :downcase, ->(hdr) { hdr.strip unless hdr.nil? }],
+              converters: [->(body) { body.encode!('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '') unless body.nil? }]).each do |row|
+      missing = missing_headers(row, csv_columns)
+      if missing.count > 0
+        errors << { row: row, message: "Missing headers: #{missing.join(', ')}" }
+        next
+      end
+
+      tutorial_code = row['code'].strip unless row['code'].nil?
+      abbreviation = row['abbreviation'].strip unless row['abbreviation'].nil?
+      unit_id = row['unit_id'].strip unless row['unit_id'].nil?
+      user_id = row['tutor_id'].strip unless row['tutor_id'].nil?
+      tutorial_stream_name = row['tutorial_stream'].strip unless row['tutorial_stream'].nil?
+
+      # find unit role using tutor's user_id and unit_id
+      unit_role = UnitRole.find_by(user_id: user_id, unit_id: unit_id)
+
+      if unit_role.nil?
+        errors << { row: row, message: "Tutor with user_id (#{user_id}) not found in unit roles" }
+        next
+      end
+
+      # if tutorial is found set it, otherwise leave it blank
+      tutorial_stream = TutorialStream.find_by(name: tutorial_stream_name) if tutorial_stream_name.present?
+
+      # handle missing tutorial stream
+      tutorial_stream = nil if tutorial_stream_name.blank?
+
+      # create a new tutorial
+      tutorial = Tutorial.new(
+        unit_id: unit_id,
+        code: tutorial_code,
+        abbreviation: abbreviation,
+        unit_role_id: unit_role.id,
+        tutorial_stream_id: tutorial_stream&.id
+      )
+
+      if tutorial.save
+        success << { row: row, message: "Created tutorial #{abbreviation} #{unit_id}" }
+      else
+        errors << {row: row, message: "Failed to create tutorial #{abbreviation} #{unit_id}" }
+      end
+    rescue StandardError => e
+      errors << { row: row, message: e.message }
+    end
+    {
+      success: success,
+      ignored: ignored,
+      errors: errors
+    }
+  end
+
+  def self.export_to_csv
+    exportables = %w[code abbreviation unit_id unit_role_id tutorial_stream_id]
+
+    # Generate the CSV file
+    CSV.generate do |csv|
+      # Add header row
+      csv << Tutorial.attribute_names.select { |attribute| exportables.include? attribute }.map do |attribute|
+        if attribute == 'tutorial_stream_id'
+          'tutorial_stream'
+        elsif attribute == 'unit_role_id'
+          'tutor_id'
+        else
+          attribute
+        end
+      end
+
+      # Add data rows
+      Tutorial.order('id').each do |tutorial|
+        csv << tutorial.attributes.select { |attribute| exportables.include? attribute }.map do |key, value|
+          # make the values more readable
+          if key == 'tutorial_stream_id'
+            stream_name = TutorialStream.find_by(id: value)&.name
+            stream_name
+          elsif key == 'unit_role_id'
+            tutor_id = UnitRole.find_by(id: value)&.user_id
+            tutor_id
+          else
+            value
+          end
+        end
+      end
+    end
   end
 
   private

--- a/app/models/tutorial.rb
+++ b/app/models/tutorial.rb
@@ -89,53 +89,60 @@ class Tutorial < ApplicationRecord
     errors = []
     ignored = []
     data = FileHelper.read_file_to_str(file).gsub('\\n', "\n")
-    CSV.parse(data,
-              headers: true,
-              header_converters: [->(i) { i.nil? ? '' : i }, :downcase, ->(hdr) { hdr.strip unless hdr.nil? }],
-              converters: [->(body) { body.encode!('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '') unless body.nil? }]).each do |row|
-      missing = missing_headers(row, csv_columns)
-      if missing.count > 0
-        errors << { row: row, message: "Missing headers: #{missing.join(', ')}" }
-        next
+
+    ActiveRecord::Base.transaction do
+      CSV.parse(data,
+                headers: true,
+                header_converters: [->(i) { i.nil? ? '' : i }, :downcase, ->(hdr) { hdr.strip unless hdr.nil? }],
+                converters: [->(body) { body.encode!('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '') unless body.nil? }]).each do |row|
+        missing = missing_headers(row, csv_columns)
+        if missing.count > 0
+          errors << { row: row, message: "Missing headers: #{missing.join(', ')}" }
+          raise StandardError, "Critical import error: missing headers"
+        end
+
+        tutorial_code = row['code'].strip unless row['code'].nil?
+        abbreviation = row['abbreviation'].strip unless row['abbreviation'].nil?
+        unit_id = row['unit_id'].strip unless row['unit_id'].nil?
+        user_id = row['tutor_id'].strip unless row['tutor_id'].nil?
+        tutorial_stream_name = row['tutorial_stream'].strip unless row['tutorial_stream'].nil?
+
+        # find unit role using tutor's user_id and unit_id
+        unit_role = UnitRole.find_by(user_id: user_id, unit_id: unit_id)
+
+        if unit_role.nil?
+          errors << { row: row, message: "Tutor with user_id (#{user_id}) not found in unit roles" }
+          raise StandardError, 'Critical import error: missing unit role'
+        end
+
+        # if tutorial is found set it, otherwise leave it blank
+        tutorial_stream = TutorialStream.find_by(name: tutorial_stream_name) if tutorial_stream_name.present?
+
+        # handle missing tutorial stream
+        tutorial_stream = nil if tutorial_stream_name.blank?
+
+        # create a new tutorial
+        tutorial = Tutorial.new(
+          unit_id: unit_id,
+          code: tutorial_code,
+          abbreviation: abbreviation,
+          unit_role_id: unit_role.id,
+          tutorial_stream_id: tutorial_stream&.id
+        )
+
+        if tutorial.save
+          success << { row: row, message: "Created tutorial #{abbreviation} #{unit_id}" }
+        else
+          errors << { row: row, message: "Failed to create tutorial #{abbreviation} #{unit_id}" }
+          raise StandardError, 'Critical import error: failed to save tutorial'
+        end
+      rescue StandardError => e
+        raise ActiveRecord::Rollback
       end
 
-      tutorial_code = row['code'].strip unless row['code'].nil?
-      abbreviation = row['abbreviation'].strip unless row['abbreviation'].nil?
-      unit_id = row['unit_id'].strip unless row['unit_id'].nil?
-      user_id = row['tutor_id'].strip unless row['tutor_id'].nil?
-      tutorial_stream_name = row['tutorial_stream'].strip unless row['tutorial_stream'].nil?
-
-      # find unit role using tutor's user_id and unit_id
-      unit_role = UnitRole.find_by(user_id: user_id, unit_id: unit_id)
-
-      if unit_role.nil?
-        errors << { row: row, message: "Tutor with user_id (#{user_id}) not found in unit roles" }
-        next
-      end
-
-      # if tutorial is found set it, otherwise leave it blank
-      tutorial_stream = TutorialStream.find_by(name: tutorial_stream_name) if tutorial_stream_name.present?
-
-      # handle missing tutorial stream
-      tutorial_stream = nil if tutorial_stream_name.blank?
-
-      # create a new tutorial
-      tutorial = Tutorial.new(
-        unit_id: unit_id,
-        code: tutorial_code,
-        abbreviation: abbreviation,
-        unit_role_id: unit_role.id,
-        tutorial_stream_id: tutorial_stream&.id
-      )
-
-      if tutorial.save
-        success << { row: row, message: "Created tutorial #{abbreviation} #{unit_id}" }
-      else
-        errors << {row: row, message: "Failed to create tutorial #{abbreviation} #{unit_id}" }
-      end
-    rescue StandardError => e
-      errors << { row: row, message: e.message }
+      raise ActiveRecord::Rollback unless errors.empty?
     end
+
     {
       success: success,
       ignored: ignored,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -296,6 +296,7 @@ class User < ApplicationRecord
       :upload_csv,
       :download_system_csv,
       :download_unit_csv,
+      :download_tutorial_csv,
 
       :create_unit,
       :admin_units,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,4 +10,5 @@ Doubtfire::Application.routes.draw do
   mount ApiRoot => '/'
   mount GrapeSwaggerRails::Engine => '/api/docs'
   mount Sidekiq::Web => "/sidekiq" # mount Sidekiq::Web in your Rails app
+  mount TutorialsApi => '/api'
 end

--- a/test/models/tutorial_model_test.rb
+++ b/test/models/tutorial_model_test.rb
@@ -21,4 +21,104 @@ class TutorialModelTest < ActiveSupport::TestCase
     assert tutorial.invalid?
     assert_equal 'Unit should be same as the unit in the associated tutorial stream', tutorial.errors.full_messages.last
   end
+
+  def test_import_from_valid_csv
+    # Setup
+    unit = FactoryBot.create(:unit)
+    tutor_user = FactoryBot.create(:user, role_id: 3) # role_id 3 for tutor
+    unit_role = FactoryBot.create(:unit_role, user: tutor_user, unit: unit) # Create the unit_role
+    tutorial_stream = FactoryBot.create(:tutorial_stream, unit: unit)
+
+    file = Tempfile.new('tutorials.csv')
+    begin
+      # Writing the test CSV data
+      file.write("code,abbreviation,unit_id,tutor_id,tutorial_stream\n")
+      file.write("CODE123,ABBR,#{unit.id},#{tutor_user.id},#{tutorial_stream.name}\n")
+      file.rewind
+
+      # Perform the CSV import
+      result = Tutorial.import_from_csv(file)
+
+      # Assert the import was successful
+      assert_equal 1, result[:success].length, result[:errors].map { |e| e[:message] }.join(", ")
+      assert_empty result[:errors], "There should be no errors"
+
+      # Check if the tutorial is correctly created
+      tutorial = Tutorial.find_by(code: 'CODE123')
+      assert_not_nil tutorial, "Tutorial should be created"
+      assert_equal 'ABBR', tutorial.abbreviation, "Tutorial abbreviation should match"
+      assert_equal unit.id, tutorial.unit_id, "Tutorial unit should match"
+
+      # Assert that the tutorial's unit_role_id matches the created unit_role
+      assert_equal unit_role.id, tutorial.unit_role_id, "Tutorial's unit_role_id should match the created unit_role"
+    ensure
+      file.close
+      file.unlink
+    end
+  end
+
+  def test_import_with_missing_headers
+    # Prepare a CSV content with a missing header (`tutor_id` is missing)
+    csv_content = <<~CSV
+      code,unit_id
+      TUT102,1
+    CSV
+    # Create a temporary file with the  CSV content
+    file = create_tempfile(csv_content)
+
+    result = Tutorial.import_from_csv(file)
+
+    # Assert that no tutorials were successfully imported
+    assert_equal 0, result[:success].size
+
+    # Assert that one error was raised due to the missing header
+    assert_equal 1, result[:errors].size
+
+    # Assert that the error message contains 'Missing headers', indicating that the import failed
+    assert_match /Missing headers/, result[:errors].first[:message]
+  ensure
+    file.close
+    file.unlink
+  end
+
+  def test_export_to_csv
+    # Ensure no tutorials exist before starting the test
+    Tutorial.delete_all
+
+    # Create necessary objects
+    unit = FactoryBot.create(:unit)
+    unit_role = FactoryBot.create(:unit_role, unit: unit, role_id: 3)  # Ensure this is a tutor role
+    tutorial_stream = FactoryBot.create(:tutorial_stream, unit: unit)
+
+    # Create the tutorial, associating it with the unit_role and tutorial_stream
+    tutorial = Tutorial.create(
+      meeting_day: "Monday",
+      meeting_time: "17:30",
+      meeting_location: "ATC101",
+      unit: unit,
+      unit_role: unit_role,
+      tutorial_stream: tutorial_stream,
+      abbreviation: "ABBR",
+      code: "CODE123"
+    )
+
+    # Export tutorials to CSV
+    csv = Tutorial.export_to_csv
+    data = CSV.parse(csv, headers: true)
+
+    # Check that the exported CSV contains the tutorial that was created
+    assert_includes data.map { |row| row['code'] }, tutorial.code, "Expected tutorial code to be included in the export"
+    assert_includes data.map { |row| row['abbreviation'] }, tutorial.abbreviation, "Expected tutorial abbreviation to be included in the export"
+    assert_includes data.map { |row| row['unit_id'] }, tutorial.unit_id.to_s, "Expected tutorial unit_id to be included in the export"
+    assert_includes data.map { |row| row['tutor_id'] }, tutorial.unit_role.user_id.to_s, "Expected tutor_id to be included in the export"
+  end
+
+  private
+
+  def create_tempfile(content)
+    file = Tempfile.new(['test_csv', '.csv'])
+    file.write(content)
+    file.rewind
+    file
+  end
 end

--- a/test_files/csv_test_files/Tutorials.csv
+++ b/test_files/csv_test_files/Tutorials.csv
@@ -1,0 +1,3 @@
+code,abbreviation,unit_id,tutor_id,tutorial_stream
+test,CS3,4,8,
+,FX1,1,2,Practical-1


### PR DESCRIPTION
# Description

This PR implements backend functionality to manage tutorials via CSV files. It introduces new POST and GET endpoints for importing and exporting tutorials, respectively. 

Key Features:
POST Endpoint (Import Tutorials from CSV):
A new POST endpoint is added to handle the import of tutorial data from CSV files.
The endpoint processes incoming CSV files, parses the data, and creates new tutorial records in the database.
Validation ensures that the CSV data is correctly formatted and matches the tutorial model before saving it to the database.

GET Endpoint (Export Tutorials to CSV):
A new GET endpoint is introduced to export tutorials as CSV files.
The endpoint generates a CSV file containing tutorial data, which can be downloaded by the user.
The exported CSV includes all relevant fields associated with the tutorials.

Integration with Tutorial Model:
The tutorial model is extended to support the import and export functionality.
Methods for parsing CSV data and converting tutorial records into CSV format are implemented directly within the tutorial model.


## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

In your terminal, change directory to doubtfire-api. If you are in doubtfire-deploy, run the following: 

`cd doubtfire-api`

Run the following to run all existing tests

`rails test`

![Screenshot 2025-04-27 at 2 42 43 PM](https://github.com/user-attachments/assets/48beaacc-52ba-40a1-b828-d791000a2c2b)

Run the following if you want to specifically run my test 

`rails test test/models/tutorial_model_test.rb`

![Screenshot 2025-04-27 at 12 03 44 PM](https://github.com/user-attachments/assets/1f17b5ea-7c91-4ca5-bca3-6e5def098612)


Additionally, if you want to test the integration, follow these steps: 

1. Pull the front-end code from https://github.com/thoth-tech/doubtfire-web/pull/314
2. Login as admin (you could also test that the tutorial panel does not show up when you login as tutor or student). The panel looks like this - 
<img src="https://github.com/user-attachments/assets/c4f09f04-51fa-4150-b25d-74069a2700aa" width="400" />

3. Navigate to the tutorial panel at the top and upload csv file. 
4. I have included a test file inside doubtfire-api/test_files/Tutorials.csv. 
5. Download this file to your computer and attempt to upload using the upload csv button. 
6. Test the download_csv button, it should download all current tutorials. 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if appropriate
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have created or extended unit tests to address my new additions
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

