### PR TITLE
feat: tutorial self enrolment task feature

### DIFF
--- a/app/api/entities/task_definition_entity.rb
+++ b/app/api/entities/task_definition_entity.rb
@@ -45,6 +45,9 @@ module Entities
     expose :scorm_bypass_test
     expose :scorm_time_delay_enabled
     expose :scorm_attempt_limit
+    expose :tutorial_self_enrolment_enabled
+    expose :tutorial_self_enrolment_stream_id
+    expose :scorm_attempt_limit
     expose :is_graded
     expose :max_quality_pts
     expose :overseer_image_id, if: ->(unit, options) { staff?(options[:my_role]) }, expose_nil: false

--- a/app/api/entities/task_definition_entity.rb
+++ b/app/api/entities/task_definition_entity.rb
@@ -33,6 +33,9 @@ module Entities
     expose :tutorial_stream_abbr do |task_definition, options|
       task_definition.tutorial_stream.abbreviation unless task_definition.tutorial_stream.nil?
     end
+    expose :tutorial_self_enrolment_stream_abbr, expose_nil: true do |task_definition, options|
+      task_definition.tutorial_self_enrolment_stream.abbreviation unless task_definition.tutorial_self_enrolment_stream.nil?
+    end
     expose :plagiarism_warn_pct, if: ->(unit, options) { staff?(options[:my_role]) }
     expose :restrict_status_updates, if: ->(unit, options) { staff?(options[:my_role]) }
     expose :group_set_id, expose_nil: false

--- a/app/api/task_definitions_api.rb
+++ b/app/api/task_definitions_api.rb
@@ -38,7 +38,7 @@ class TaskDefinitionsApi < Grape::API
       optional :scorm_bypass_test,        type: Boolean,  desc: 'Whether a student is allowed to upload files before passing SCORM test'
       optional :scorm_time_delay_enabled, type: Boolean,  desc: 'Whether there is an incremental time delay between SCORM test attempts'
       optional :scorm_attempt_limit,      type: Integer,  desc: 'The number of times a SCORM test can be attempted'
-      optional :tutorial_self_enrolment_enabled,        type: Integer,  desc: 'Whether the tutorial self enrolment feature is enabled for this task'
+      optional :tutorial_self_enrolment_enabled,        type: Boolean,  desc: 'Whether the tutorial self enrolment feature is enabled for this task'
       optional :tutorial_self_enrolment_stream_id,      type: Integer,  desc: 'The id of the tutorial stream to fetch tutorials from for self enrolment'
     end
   end
@@ -130,7 +130,7 @@ class TaskDefinitionsApi < Grape::API
       optional :assessment_enabled,       type: Boolean,  desc: 'Enable or disable assessment'
       optional :overseer_image_id,        type: Integer,  desc: 'The id of the Docker image name for overseer'
       optional :moss_language,            type: String,   desc: 'The language to use for code similarity checks'
-      optional :tutorial_self_enrolment_enabled,          type: Integer,  desc: 'Whether the tutorial self enrolment feature is enabled for this task'
+      optional :tutorial_self_enrolment_enabled,          type: Boolean,  desc: 'Whether the tutorial self enrolment feature is enabled for this task'
       optional :tutorial_self_enrolment_stream_id,        type: Integer,  desc: 'The id of the tutorial stream to fetch tutorials from for self enrolment'
     end
   end

--- a/app/api/task_definitions_api.rb
+++ b/app/api/task_definitions_api.rb
@@ -38,6 +38,8 @@ class TaskDefinitionsApi < Grape::API
       optional :scorm_bypass_test,        type: Boolean,  desc: 'Whether a student is allowed to upload files before passing SCORM test'
       optional :scorm_time_delay_enabled, type: Boolean,  desc: 'Whether there is an incremental time delay between SCORM test attempts'
       optional :scorm_attempt_limit,      type: Integer,  desc: 'The number of times a SCORM test can be attempted'
+      optional :tutorial_self_enrolment_enabled,        type: Integer,  desc: 'Whether the tutorial self enrolment feature is enabled for this task'
+      optional :tutorial_self_enrolment_stream_id,      type: Integer,  desc: 'The id of the tutorial stream to fetch tutorials from for self enrolment'
     end
   end
   post '/units/:unit_id/task_definitions/' do
@@ -65,6 +67,8 @@ class TaskDefinitionsApi < Grape::API
                                                 :scorm_bypass_test,
                                                 :scorm_time_delay_enabled,
                                                 :scorm_attempt_limit,
+                                                :tutorial_self_enrolment_enabled,
+                                                :tutorial_self_enrolment_stream_id,
                                                 :is_graded,
                                                 :max_quality_pts,
                                                 :assessment_enabled,
@@ -126,6 +130,8 @@ class TaskDefinitionsApi < Grape::API
       optional :assessment_enabled,       type: Boolean,  desc: 'Enable or disable assessment'
       optional :overseer_image_id,        type: Integer,  desc: 'The id of the Docker image name for overseer'
       optional :moss_language,            type: String,   desc: 'The language to use for code similarity checks'
+      optional :tutorial_self_enrolment_enabled,          type: Integer,  desc: 'Whether the tutorial self enrolment feature is enabled for this task'
+      optional :tutorial_self_enrolment_stream_id,        type: Integer,  desc: 'The id of the tutorial stream to fetch tutorials from for self enrolment'
     end
   end
   put '/units/:unit_id/task_definitions/:id' do
@@ -154,6 +160,8 @@ class TaskDefinitionsApi < Grape::API
                                                 :scorm_bypass_test,
                                                 :scorm_time_delay_enabled,
                                                 :scorm_attempt_limit,
+                                                :tutorial_self_enrolment_enabled,
+                                                :tutorial_self_enrolment_stream_id,
                                                 :is_graded,
                                                 :max_quality_pts,
                                                 :assessment_enabled,

--- a/app/api/task_definitions_api.rb
+++ b/app/api/task_definitions_api.rb
@@ -39,7 +39,7 @@ class TaskDefinitionsApi < Grape::API
       optional :scorm_time_delay_enabled, type: Boolean,  desc: 'Whether there is an incremental time delay between SCORM test attempts'
       optional :scorm_attempt_limit,      type: Integer,  desc: 'The number of times a SCORM test can be attempted'
       optional :tutorial_self_enrolment_enabled,        type: Boolean,  desc: 'Whether the tutorial self enrolment feature is enabled for this task'
-      optional :tutorial_self_enrolment_stream_id,      type: Integer,  desc: 'The id of the tutorial stream to fetch tutorials from for self enrolment'
+      optional :tutorial_self_enrolment_stream_abbr,    type: String,   desc: 'The abbreviation of tutorial stream to fetch from for self enrolment'
     end
   end
   post '/units/:unit_id/task_definitions/' do
@@ -68,7 +68,6 @@ class TaskDefinitionsApi < Grape::API
                                                 :scorm_time_delay_enabled,
                                                 :scorm_attempt_limit,
                                                 :tutorial_self_enrolment_enabled,
-                                                :tutorial_self_enrolment_stream_id,
                                                 :is_graded,
                                                 :max_quality_pts,
                                                 :assessment_enabled,
@@ -88,6 +87,14 @@ class TaskDefinitionsApi < Grape::API
     unless tutorial_stream_abbr.nil?
       tutorial_stream = unit.tutorial_streams.find_by!(abbreviation: tutorial_stream_abbr)
       task_def.tutorial_stream = tutorial_stream
+    end
+
+    # Set the self enrolment tutorial stream
+    tutorial_self_enrolment_stream_abbr = params[:task_def][:tutorial_self_enrolment_stream_abbr]
+    unless tutorial_self_enrolment_stream_abbr.nil?
+      tutorial_self_enrolment_stream = task_def.unit.tutorial_streams.find_by!(abbreviation: tutorial_self_enrolment_stream_abbr)
+      task_def.tutorial_self_enrolment_stream = tutorial_self_enrolment_stream
+      task_def.save!
     end
 
     #
@@ -130,8 +137,8 @@ class TaskDefinitionsApi < Grape::API
       optional :assessment_enabled,       type: Boolean,  desc: 'Enable or disable assessment'
       optional :overseer_image_id,        type: Integer,  desc: 'The id of the Docker image name for overseer'
       optional :moss_language,            type: String,   desc: 'The language to use for code similarity checks'
-      optional :tutorial_self_enrolment_enabled,          type: Boolean,  desc: 'Whether the tutorial self enrolment feature is enabled for this task'
-      optional :tutorial_self_enrolment_stream_id,        type: Integer,  desc: 'The id of the tutorial stream to fetch tutorials from for self enrolment'
+      optional :tutorial_self_enrolment_enabled,      type: Boolean,  desc: 'Whether the tutorial self enrolment feature is enabled for this task'
+      optional :tutorial_self_enrolment_stream_abbr,  type: String,   desc: 'The abbreviation of tutorial stream to fetch from for self enrolment'
     end
   end
   put '/units/:unit_id/task_definitions/:id' do
@@ -161,7 +168,6 @@ class TaskDefinitionsApi < Grape::API
                                                 :scorm_time_delay_enabled,
                                                 :scorm_attempt_limit,
                                                 :tutorial_self_enrolment_enabled,
-                                                :tutorial_self_enrolment_stream_id,
                                                 :is_graded,
                                                 :max_quality_pts,
                                                 :assessment_enabled,
@@ -194,6 +200,14 @@ class TaskDefinitionsApi < Grape::API
     unless tutorial_stream_abbr.nil?
       tutorial_stream = task_def.unit.tutorial_streams.find_by!(abbreviation: tutorial_stream_abbr)
       task_def.tutorial_stream = tutorial_stream
+      task_def.save!
+    end
+
+    # Set the self enrolment tutorial stream
+    tutorial_self_enrolment_stream_abbr = params[:task_def][:tutorial_self_enrolment_stream_abbr]
+    unless tutorial_self_enrolment_stream_abbr.nil?
+      tutorial_self_enrolment_stream = task_def.unit.tutorial_streams.find_by!(abbreviation: tutorial_self_enrolment_stream_abbr)
+      task_def.tutorial_self_enrolment_stream = tutorial_self_enrolment_stream
       task_def.save!
     end
 

--- a/app/models/task_definition.rb
+++ b/app/models/task_definition.rb
@@ -12,6 +12,7 @@ class TaskDefinition < ApplicationRecord
   belongs_to :unit, optional: false # Foreign key
   belongs_to :group_set, optional: true
   belongs_to :tutorial_stream, optional: true
+  belongs_to :tutorial_self_enrolment_stream, class_name: "TutorialStream", optional: true
   belongs_to :overseer_image, optional: true
 
   has_many :tasks, dependent:  :destroy # Destroying a task definition will also nuke any instances

--- a/app/models/task_definition.rb
+++ b/app/models/task_definition.rb
@@ -449,6 +449,10 @@ class TaskDefinition < ApplicationRecord
     scorm_attempt_limit
   end
 
+  def tutorial_self_enrolment_enabled?
+    tutorial_self_enrolment_enabled
+  end
+
   def is_graded?
     is_graded
   end

--- a/db/migrate/20250506044920_tutorial_self_enrolment_feature.rb
+++ b/db/migrate/20250506044920_tutorial_self_enrolment_feature.rb
@@ -1,0 +1,6 @@
+class TutorialSelfEnrolmentFeature < ActiveRecord::Migration[7.1]
+  def change
+    add_column :task_definitions, :tutorial_self_enrolment_enabled, :boolean, default: false
+    add_reference :task_definitions, :tutorial_self_enrolment_stream, foreign_key: { to_table: :tutorial_streams }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_12_17_091744) do
+ActiveRecord::Schema[7.1].define(version: 2025_05_06_044920) do
   create_table "activity_types", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "abbreviation", null: false
@@ -272,10 +272,13 @@ ActiveRecord::Schema[7.1].define(version: 2024_12_17_091744) do
     t.boolean "scorm_bypass_test", default: false
     t.boolean "scorm_time_delay_enabled", default: false
     t.integer "scorm_attempt_limit", default: 0
+    t.boolean "tutorial_self_enrolment_enabled", default: false
+    t.bigint "tutorial_self_enrolment_stream_id"
     t.index ["abbreviation", "unit_id"], name: "index_task_definitions_on_abbreviation_and_unit_id", unique: true
     t.index ["group_set_id"], name: "index_task_definitions_on_group_set_id"
     t.index ["name", "unit_id"], name: "index_task_definitions_on_name_and_unit_id", unique: true
     t.index ["overseer_image_id"], name: "index_task_definitions_on_overseer_image_id"
+    t.index ["tutorial_self_enrolment_stream_id"], name: "index_task_definitions_on_tutorial_self_enrolment_stream_id"
     t.index ["tutorial_stream_id"], name: "index_task_definitions_on_tutorial_stream_id"
     t.index ["unit_id"], name: "index_task_definitions_on_unit_id"
   end
@@ -591,6 +594,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_12_17_091744) do
     t.index ["user_id"], name: "index_webcals_on_user_id", unique: true
   end
 
+  add_foreign_key "task_definitions", "tutorial_streams", column: "tutorial_self_enrolment_stream_id"
   add_foreign_key "user_oauth_states", "users"
   add_foreign_key "user_oauth_tokens", "users"
 end


### PR DESCRIPTION
# Description

This feature will allow staff to enable the "Tutorial self enrolment" feature for a designated task. Staff will select which tutorial stream(s) to fetch the tutorials from, and students will be prompted with the list of tutorials they must choose from to complete the task.

## How has this been tested?
Ensure you are also using the Front End branch:
https://github.com/thoth-tech/doubtfire-web/pull/306

1. Login as aadmin
2. Select any unit and any task to edit
3. Scroll to the "Tutorial enrolment form" and enable it
4. Select a tutorial stream that has a atleast a few tutorials
5. If there are no tutorial streams to choose from or the stream has no tutorials, manually add them in the in the tutorials tab.
6. Save the changes to the task after enabling the self enrolment form.
7. Now login as student_1, and navigate to the same unit and task you enabled the form for.
8. Click on "Begin enrolment", and confirm the list of tutorials show up. Do note that some tutorials may not show up for a student based on their campus. Eg. if a student is based on campus X, but the tutorial is only available for campus Y, the student will not see it.
9. Select a tutorial and click enrol.
10. If it says you have already been enrolled, you can navigate to the Tutorial List and withdraw yourself from the unit, then go back to the task to begin tutorial enrolment, and select a tutorial

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
