### PR TITLE
Fix IDOR user test

### DIFF
--- a/app/api/users_api.rb
+++ b/app/api/users_api.rb
@@ -21,7 +21,8 @@ class UsersApi < Grape::API
   desc 'Get user'
   get '/users/:id', requirements: { id: /[0-9]*/ } do
     user = User.find(params[:id])
-    unless (user.id == current_user.id) || (authorise? current_user, User, :admin_users)
+    # Users may only access their own data unless they are teaching staff
+    unless user.id == current_user.id || Role.teaching_staff_ids.include?(current_user.role_id)
       error!({ error: "Cannot find User with id #{params[:id]}" }, 403)
     end
 

--- a/test/api/users_test.rb
+++ b/test/api/users_test.rb
@@ -65,18 +65,29 @@ class UnitsTest < ActiveSupport::TestCase
     # Add username and auth_token to Header
     add_auth_header_for(user: User.first)
 
-    # perform the GET 
+    # perform the GET
     get "/api/users/#{expected_user.id}"
     returned_user = last_response_body
 
     # Check if the call succeeds
     assert_equal 200, last_response.status
-    
+
     # Check the returned details match as expected
     response_keys = %w(first_name last_name email student_id nickname receive_task_notifications receive_portfolio_notifications receive_feedback_notifications opt_in_to_research has_run_first_time_setup)
     assert_json_matches_model(expected_user, returned_user, response_keys)
   end
-  
+
+  def test_student_cannot_access_other_user
+    student = create(:user, :student)
+    other_student = create(:user, :student)
+
+    add_auth_header_for(user: student)
+
+    get "/api/users/#{other_student.id}"
+
+    assert_equal 403, last_response.status
+  end
+
   def test_get_convenors
 
     # Add username and auth_token to Header


### PR DESCRIPTION
Ensure users can only access their own data unless they have teaching staff roles. Added a regression test.

# Description

Implement proper authorisation checks in the user controller to prevent users from accessing other users' data by manipulating IDs. 

Fixes # (issue)
1. The access check should ensure that only the user themselves or a teaching staff member can retrieve a user profile. Replace the outdated authorise? current_user, User, :admin_users check with Role.teaching_staff_ids.include?(current_user.role_id) so all teaching roles (e.g., tutors, convenors, admins) are covered.
2. Added a regression test ensuring a student cannot retrieve another student’s profile, expecting a 403 response
## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
yes

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if appropriate
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have created or extended unit tests to address my new additions
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

If you have any questions, please contact @macite or @jakerenzella.
