### PR TITLE
fix(api): Remove default nulls to fix Swagger

### DIFF
--- a/app/api/api_root.rb
+++ b/app/api/api_root.rb
@@ -128,7 +128,7 @@ class ApiRoot < Grape::API
     api_version: 'v1',
     hide_documentation_path: true,
     info: {
-      title: 'Doubtfire API Documentaion',
+      title: 'Doubtfire API Documentation',
       description: 'Doubtfire is a modern, lightweight learning management system.',
       license: 'AGPL v3.0',
       license_url: 'https://github.com/doubtfire-lms/doubtfire-api/blob/master/LICENSE'

--- a/app/api/tii/tii_action_api.rb
+++ b/app/api/tii/tii_action_api.rb
@@ -12,7 +12,9 @@ module Tii
 
     desc 'Get the outstanding turn it in actions'
     params do
-      optional :unit_id, type: Integer, desc: 'The id of the unit to filter by', default: nil
+      optional :unit_id, type: Integer, desc: 'The id of the unit to filter by' # , default: nil
+      # `default: nil` is not allowed in Swagger 2.0 endpoints
+      # https://github.com/swagger-api/swagger-spec/issues/229.
       optional :limit, type: Integer, desc: 'The maximum number of actions to return', default: 50
       optional :offset, type: Integer, desc: 'The offset to start from', default: 0
       optional :show_complete, type: Boolean, desc: 'Include complete actions?', default: false
@@ -38,7 +40,7 @@ module Tii
     desc 'Trigger an action on the given group attachment'
     params do
       requires :action, type: String, desc: 'The action to perform: retry'
-      optional :unit_id, type: Integer, desc: 'The id of the unit to filter by', default: nil
+      optional :unit_id, type: Integer, desc: 'The id of the unit to filter by' # , default: nil https://github.com/swagger-api/swagger-spec/issues/229
     end
     put '/tii_actions/:id' do
       unit = Unit.find(params[:unit_id]) if params[:unit_id].present?


### PR DESCRIPTION
Until recently, the Swagger doc returned from /api/swagger_doc contained Ruby parameter `default` set to "Nil", informing Swagger that an endpoint was nullable. This behaviour is not supported by Swagger 2.0.

<img width="1243" height="857" alt="image" src="https://github.com/user-attachments/assets/5bb75712-17a7-40e9-86bd-968a6c0bd667" />

Commented out the unnecessary optional default null values for the `unit_id` parameters for the "Turn It In actions" endpoints `/api/tii_actions`.

<img width="1019" height="832" alt="image" src="https://github.com/user-attachments/assets/d4706e7a-3d06-4423-8d4e-9158c312a337" />

A more robust fix may come from migrating to OpenAPI 3.1, which would allow types to be specified as nullable.

__Fixes:__ a rendering issue with Swagger (I would have opened an issue, but this repository does not allow opening issues for some reason?)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test A
  * run the Formatif dev container locally in VSCode using commit with hash beginning `363e02e`
  * navigate to `localhost:3000/api/docs` in a browser
  * Notice that the Swagger document does not render
  * If desired, open Devtools and navigate to the console to inspect the uncaught exception
- [x] Test B
  * run the Formatif dev container locally in VSCode using any commit from or after hash beginning `bd77e94`
  * navigate to `localhost:3000/api/docs` in a browser
  * Notice that the Swagger document has now rendered as expected

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if appropriate
- [x] My changes generate no new warnings
- [x] ~~I have added tests that prove my fix is effective or that my feature works~~ N/A
- [x] ~~I have created or extended unit tests to address my new additions~~ N/A
- [x] New and existing unit tests pass locally with my changes
  * __Note:__ not all unit tests were passed successfully under hash begininng `363e02e`. Regardless, no new tests were failed as a result of including any commit from or after hash beginning `bd77e94`
- [x] ~~Any dependent changes have been merged and published in downstream modules~~ N/A

If you have any questions, please contact @macite or @jakerenzella.
