### PR TITLE
fix: tighten API CORS policy to trusted origins

### DIFF
--- a/app/api/api_root.rb
+++ b/app/api/api_root.rb
@@ -10,9 +10,6 @@ class ApiRoot < Grape::API
   format :json
 
   before do
-    header['Access-Control-Allow-Origin'] = '*'
-    header['Access-Control-Request-Method'] = '*'
-
     Thread.current.thread_variable_set(:ip, request.ip)
   end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -244,10 +244,27 @@ module Doubtfire
       Rails.root.join('app/models/d2l')
 
     # CORS config
+    # Configure a strict allowlist. Override per environment via:
+    # CORS_ALLOWED_ORIGINS="http://localhost:4200,https://frontend.example.edu"
+    default_cors_origins = [
+      'http://localhost:4200',
+      "https://#{config.institution[:host]}"
+    ].uniq
+    allowed_cors_origins = ENV.fetch('CORS_ALLOWED_ORIGINS', default_cors_origins.join(','))
+                              .split(',')
+                              .map(&:strip)
+                              .reject(&:empty?)
+                              .uniq
+
     config.middleware.insert_before Warden::Manager, Rack::Cors do
       allow do
-        origins '*'
-        resource '*', headers: :any, methods: %i(get post put delete options)
+        origins do |source, _env|
+          allowed_cors_origins.include?(source)
+        end
+
+        resource '*',
+                 headers: %w[Content-Type Authorization Accept],
+                 methods: %i[get post put delete options]
       end
     end
 


### PR DESCRIPTION
Description
This fix addresses a misconfigured CORS policy that allowed any external origin to make cross-origin requests to the Doubtfire API. Previously, the server responded with Access-Control-Allow-Origin: * and accepted any headers and methods, meaning malicious websites could send requests to the API via a victim's browser.
Changes made:
doubtfire-api/config/application.rb

Replaced the wildcard origins '*' with a strict origin allowlist
Default trusted origins include http://localhost:4200 and https://#{config.institution[:host]}
Added optional override via CORS_ALLOWED_ORIGINS environment variable (comma-separated)
Added explicit Origin validation logic that checks the incoming Origin header against the allowlist before permitting CORS
Restricted allowed headers to: Content-Type, Authorization, Accept
Restricted allowed methods to: GET, POST, PUT, DELETE, OPTIONS

doubtfire-api/app/api/api_root.rb

Removed manual wildcard CORS headers from the API before block (Access-Control-Allow-Origin: * and Access-Control-Request-Method: *)
Request IP thread variable logic was left untouched

Fixes # (CORS misconfiguration issue)
Type of change

 Bug fix (non-breaking change which fixes an issue)

How Has This Been Tested?
The fix was verified using Burp Suite Repeater and curl from a Kali Linux machine targeting the Windows-hosted API.
Test 1 — Untrusted origin is blocked:

 Sent GET /api/activity_types HTTP/1.1 with header Origin: https://evil.com
 Confirmed response does not return Access-Control-Allow-Origin: * or echo back evil.com

Test 2 — Trusted origin is allowed:

 Sent same request with header Origin: http://localhost:4200
 Confirmed response returns Access-Control-Allow-Origin: http://localhost:4200

curl command used:
bashcurl -X GET http://localhost:3000/api/activity_types \
  -H "Origin: https://evil.com" \
  -H "Accept: application/json" \
  -v 2>&1 | grep -i "access-control"
Checklist:

 My code follows the style guidelines of this project
 I have performed a self-review of my own code
 I have commented my code, particularly in hard-to-understand areas
 I have made corresponding changes to the documentation if appropriate
 My changes generate no new warnings
 I have added tests that prove my fix is effective or that my feature works
 I have created or extended unit tests to address my new additions
 New and existing unit tests pass locally with my changes
 Any dependent changes have been merged and published in downstream modules