### PR TITLE
Fix missing security headers for API responses

### DIFF
--- a/app/api/api_root.rb
+++ b/app/api/api_root.rb
@@ -10,6 +10,11 @@ class ApiRoot < Grape::API
   format :json
 
   before do
+    header['X-Frame-Options'] = 'DENY'
+    header['X-Content-Type-Options'] = 'nosniff'
+    header['Referrer-Policy'] = 'no-referrer'
+    header['Permissions-Policy'] = 'geolocation=(), camera=(), microphone=()'
+    header['Content-Security-Policy'] = "default-src 'self'; frame-ancestors 'none'; object-src 'none'; base-uri 'self';"
     header['Access-Control-Allow-Origin'] = '*'
     header['Access-Control-Request-Method'] = '*'
 
@@ -94,6 +99,7 @@ class ApiRoot < Grape::API
   mount TutorialEnrolmentsApi
   mount UnitRolesApi
   mount UnitsApi
+  mount TutorNotesApi
 
   mount D2lIntegrationApi::D2lApi
   mount D2lIntegrationApi::OauthPublicApi
@@ -102,6 +108,8 @@ class ApiRoot < Grape::API
   mount WebcalApi
   mount WebcalPublicApi
   mount MarkingSessionsApi
+  mount DiscussionPromptsApi
+  mount OverseerStepsApi
 
   mount Feedback::FeedbackChipApi
 
@@ -150,13 +158,16 @@ class ApiRoot < Grape::API
   AuthenticationHelpers.add_auth_to D2lIntegrationApi::D2lApi
   AuthenticationHelpers.add_auth_to Feedback::FeedbackChipApi
   AuthenticationHelpers.add_auth_to MarkingSessionsApi
+  AuthenticationHelpers.add_auth_to DiscussionPromptsApi
+  AuthenticationHelpers.add_auth_to OverseerStepsApi
+  AuthenticationHelpers.add_auth_to TutorNotesApi
 
   add_swagger_documentation \
     base_path: nil,
-    api_version: 'v1',
+    doc_version: 'v10.0.0',
     hide_documentation_path: true,
     info: {
-      title: 'Doubtfire API Documentaion',
+      title: 'Doubtfire API Documentation',
       description: 'Doubtfire is a modern, lightweight learning management system.',
       license: 'AGPL v3.0',
       license_url: 'https://github.com/doubtfire-lms/doubtfire-api/blob/master/LICENSE'


### PR DESCRIPTION
Description

This fix addresses missing HTTP security headers in Doubtfire API responses. Previously, API responses did not consistently include important browser-side protections such as Content-Security-Policy, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, and Permissions-Policy. The absence of these headers increased exposure to risks such as clickjacking, MIME sniffing, cross-site scripting (XSS), and unnecessary browser feature access.

Changes made:

doubtfire-api/app/api/api_root.rb

Added global security headers inside the API before block so all API responses receive them:

X-Frame-Options: DENY
X-Content-Type-Options: nosniff
Referrer-Policy: no-referrer
Permissions-Policy: geolocation=(), camera=(), microphone=()
Content-Security-Policy: default-src 'self'; frame-ancestors 'none'; object-src 'none'; base-uri 'self';

Existing Access-Control-Allow-Origin and Access-Control-Request-Method headers were left unchanged
Request IP thread variable logic was left untouched

Fixes # (Missing Security Headers issue)

Type of change

Bug fix (non-breaking change which fixes an issue)

How Has This Been Tested?

The fix was verified locally using curl and OWASP ZAP against the Rails API running on localhost:3000.

Test 1 — curl header validation:

Sent request to:
GET /api/activity_types

Confirmed response now includes:
X-Frame-Options
X-Content-Type-Options
Referrer-Policy
Permissions-Policy
Content-Security-Policy

curl command used:

curl -I http://localhost:3000/api/activity_types

<img width="1512" height="982" alt="Screenshot 2026-04-26 at 7 15 52 pm" src="https://github.com/user-attachments/assets/3bcc2cfb-950d-4d12-8351-af7da2776d35" />

Test 2 — OWASP ZAP validation:

Ran automated scan against:
http://localhost:3000/

Confirmed previous alerts for missing security headers were no longer present:
Content Security Policy (CSP) Header Not Set
Missing Anti-clickjacking Header
X-Content-Type-Options Header Missing
Referrer Policy Missing

Before fix -
<img width="1512" height="982" alt="Screenshot 2026-04-26 at 6 59 40 pm" src="https://github.com/user-attachments/assets/8835a7c5-37a8-45f9-b4b8-0ecd49243a2b" />

After fix -
<img width="1509" height="881" alt="Screenshot 2026-04-26 at 7 35 27 pm" src="https://github.com/user-attachments/assets/dba99e95-4a41-40f0-8a1c-d0e02603a2cf" />

No alerts of security header

Checklist:

[x] My code follows the style guidelines of this project
[x] I have performed a self-review of my own code
[x] My changes generate no new warnings
[x] I have tested the fix locally
[x] New and existing functionality still loads correctly