### PR TITLE
Fix/settings api auth

### DIFF
--- a/app/api/settings_api.rb
+++ b/app/api/settings_api.rb
@@ -1,6 +1,12 @@
 require 'grape'
 
 class SettingsApi < Grape::API
+  helpers AuthenticationHelpers
+
+  before do
+    authenticated?
+  end
+
   #
   # Returns the current auth method
   #


### PR DESCRIPTION
# Description

This PR resolves an unauthenticated access vulnerability in the SettingsApi endpoint. Previously, the /settings endpoint was publicly accessible without authentication. By incorporating AuthenticationHelpers and enforcing before { authenticated? }, access to the configuration settings endpoint now strictly requires an authenticated user session.

Fixes Finding 6.6 in the Vulnerability Remediation Report.
<img width="848" height="185" alt="Screenshot 2026-07-24 at 10 36 36 am" src="https://github.com/user-attachments/assets/9224e961-ecf2-4997-a2b1-9df12879f3bc" />


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Executed curl -i http://localhost:3000/api/settings without authentication headers.
- Result: Confirmed the endpoint rejects unauthenticated requests, returning an internal 419 CUSTOM status code with the payload {"error":"No authentication details provided. Authentication is required to access this resource."}.
<img width="711" height="172" alt="Screenshot 2026-07-24 at 10 25 52 am" src="https://github.com/user-attachments/assets/f6c01c05-30cb-47d2-b2f9-5ab40318399b" />



# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if appropriate
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have created or extended unit tests to address my new additions
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules